### PR TITLE
Fix NPC/location cards on mobile: readable portraits and no text clip…

### DIFF
--- a/src/styles/NPC.module.css
+++ b/src/styles/NPC.module.css
@@ -174,13 +174,37 @@
     .card,
     .card:nth-child(even) {
         flex-direction: column;
+        /* Row layout min-height fights column stacking: body was flex-shrinking and got clipped by overflow:hidden */
+        min-height: 0;
+        align-items: stretch;
     }
 
     .image {
+        flex: 0 0 auto;
+        flex-shrink: 0;
+        width: 100%;
+        /* Tall enough that portraits (contain) read at a glance; no aggressive vertical crop */
+        height: clamp(16rem, 58vw, 24rem);
+        min-height: 0;
+        max-height: min(24rem, 70vw);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .image img {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        object-fit: contain;
+        object-position: center center;
+    }
+
+    .body {
         flex: none;
         width: 100%;
-        min-height: 14rem;
-        max-height: 20rem;
+        min-width: 0;
+        overflow: visible;
     }
 
     .card:nth-child(even) .image::after {


### PR DESCRIPTION
…ping

Use object-fit contain and taller image band under 768px so character art stays recognizable. Keep column flex fixes so body text is not clipped by overflow.