### PR TITLE
Refine header with a royal fantasy nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -43,6 +43,9 @@ import HeaderLink from './HeaderLink.astro';
             0 0 0 1px rgb(214 173 100 / 18%),
             0 14px 34px rgb(0 0 0 / 32%);
     }
+    nav :global(a) {
+        margin: 0;
+    }
     nav::before {
         content: '';
         position: absolute;
@@ -90,12 +93,14 @@ import HeaderLink from './HeaderLink.astro';
 
     @media only screen and (max-width: 768px) {
         nav {
-            gap: 0.04rem;
-            padding: 0.55rem 0.65rem 0.62rem;
+            gap: 0.28rem 0.4rem;
+            padding: 0.48rem 0.48rem 0.54rem;
+        }
+        nav::before {
+            inset: 5px;
         }
         .nav-separator {
-            width: 0.95rem;
-            flex-basis: 0.95rem;
+            display: none;
         }
     }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,23 +5,97 @@ import HeaderLink from './HeaderLink.astro';
 <header>
     <nav>
         <HeaderLink href="/justus-league/">Home</HeaderLink>
+        <span class="nav-separator" aria-hidden="true">✦</span>
         <HeaderLink href="/justus-league/sessions">Sessions</HeaderLink>
+        <span class="nav-separator" aria-hidden="true">✦</span>
         <HeaderLink href="/justus-league/characters">Justus-League</HeaderLink>
+        <span class="nav-separator" aria-hidden="true">✦</span>
         <HeaderLink href="/justus-league/npc">NPC's</HeaderLink>
+        <span class="nav-separator" aria-hidden="true">✦</span>
         <HeaderLink href="/justus-league/locations">Locaties</HeaderLink>
     </nav>
 </header>
 <style>
     header {
-        margin: 0em 0 2em;
+        margin: 0 0 2em;
+        position: relative;
     }
-    h2 {
-        margin: 0.5em 0;
+    nav {
+        position: relative;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+        gap: 0.08rem;
+        padding: 0.68rem 1rem 0.78rem;
+        border: 1px solid rgb(174 130 74 / 78%);
+        border-radius: 12px;
+        background: linear-gradient(
+            180deg,
+            rgb(78 56 38 / 95%) 0%,
+            rgb(50 34 24 / 97%) 45%,
+            rgb(34 24 19 / 98%) 100%
+        );
+        box-shadow:
+            inset 0 1px 0 rgb(255 230 185 / 24%),
+            inset 0 -1px 0 rgb(45 30 21 / 85%),
+            inset 0 0 0 1px rgb(33 24 19 / 72%),
+            0 0 0 1px rgb(214 173 100 / 18%),
+            0 14px 34px rgb(0 0 0 / 32%);
+    }
+    nav::before {
+        content: '';
+        position: absolute;
+        inset: 7px;
+        border-radius: 9px;
+        pointer-events: none;
+        border: 1px solid rgb(231 194 127 / 35%);
+        box-shadow:
+            inset 0 1px 0 rgb(255 228 170 / 12%),
+            inset 0 -1px 0 rgb(122 85 47 / 22%);
+    }
+    nav::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        top: -11px;
+        transform: translateX(-50%);
+        width: min(12rem, 52%);
+        height: 18px;
+        pointer-events: none;
+        background: linear-gradient(
+            90deg,
+            transparent,
+            rgb(237 199 126 / 42%),
+            transparent
+        );
+        filter: blur(2.5px);
+    }
+    .nav-separator {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.15rem;
+        flex: 0 0 1.15rem;
+        color: #e4bb6a;
+        font-size: 0.82rem;
+        margin: 0;
+        line-height: 1;
+        pointer-events: none;
+        user-select: none;
+        text-shadow:
+            0 0 10px rgb(244 202 113 / 52%),
+            0 1px 0 rgb(74 50 30 / 70%);
     }
 
     @media only screen and (max-width: 768px) {
         nav {
-            text-align: center;
+            gap: 0.04rem;
+            padding: 0.55rem 0.65rem 0.62rem;
+        }
+        .nav-separator {
+            width: 0.95rem;
+            flex-basis: 0.95rem;
         }
     }
 </style>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -13,17 +13,60 @@ const isActive = href === pathname || href === pathname.replace(/\/$/, '');
 <style>
     a {
         display: inline-block;
+        padding: 0.1rem 0.5rem;
+        font-family: 'PirataOne-Regular', system-ui, sans-serif;
+        font-size: clamp(1.08rem, 2.05vw, 1.3rem);
+        letter-spacing: 0.045em;
         text-decoration: none;
-        color: white;
+        color: #ddb470;
+        text-shadow:
+            0 0 15px rgba(221, 180, 112, 0.35),
+            0 1px 0 #1e1410,
+            0 2px 8px rgba(0, 0, 0, 0.68);
+        border-radius: 6px;
+        transition:
+            color 0.18s ease,
+            background-color 0.18s ease,
+            box-shadow 0.18s ease,
+            text-shadow 0.18s ease,
+            transform 0.12s ease;
+    }
+    a:hover {
+        color: #ffefcd;
+        background: linear-gradient(
+            180deg,
+            rgb(236 196 118 / 18%) 0%,
+            rgb(221 180 112 / 8%) 100%
+        );
+        text-shadow:
+            0 0 20px rgba(242, 204, 127, 0.68),
+            0 1px 0 #2a1c14,
+            0 3px 10px rgba(0, 0, 0, 0.74);
+        box-shadow: inset 0 0 0 1px rgb(236 196 118 / 22%);
+        transform: translateY(-0.5px);
     }
     a.active {
-        font-weight: bolder;
-        text-decoration: underline;
+        color: #fff0ca;
+        text-decoration: none;
+        background: linear-gradient(
+            180deg,
+            rgb(236 196 118 / 28%) 0%,
+            rgb(236 196 118 / 10%) 100%
+        );
+        text-shadow:
+            0 0 24px rgba(242, 204, 127, 0.85),
+            0 1px 0 #2a1c14,
+            0 4px 12px rgba(0, 0, 0, 0.78);
+        box-shadow:
+            inset 0 1px 0 rgb(255 228 170 / 22%),
+            inset 0 -1px 0 rgb(127 90 53 / 35%),
+            0 0 0 1px rgb(236 196 118 / 42%);
     }
 
     @media only screen and (max-width: 768px) {
         a {
-            font-size: 18px;
+            padding: 0.08rem 0.28rem;
+            font-size: 1.03rem;
         }
     }
 </style>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -65,8 +65,9 @@ const isActive = href === pathname || href === pathname.replace(/\/$/, '');
 
     @media only screen and (max-width: 768px) {
         a {
-            padding: 0.08rem 0.28rem;
-            font-size: 1.03rem;
+            padding: 0.08rem 0.2rem;
+            font-size: 0.98rem;
+            letter-spacing: 0.03em;
         }
     }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,13 +118,6 @@ const ogImageUrl = new URL(og.src, Astro.site).href;
                 z-index: 0;
             }
 
-            body:has(.fantasy-page) nav a {
-                color: #d8c8a8;
-            }
-
-            body:has(.fantasy-page) nav a:hover {
-                color: #f4e8d4;
-            }
         </style>
         <style>
             .fantasy-page {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -140,7 +140,7 @@ a:hover {
     text-decoration: underline;
 }
 nav a {
-    margin-right: 10px;
+    margin: 0 10px;
 }
 textarea {
     width: 100%;


### PR DESCRIPTION
## Summary
- redesign the shared header nav into a royal fantasy plaque with richer gold tones, carved framing, and ambient highlight treatment
- style header links with improved fantasy typography, hover/active lighting, and consistent accent behavior across pages
- add standalone decorative star separators between links and tune spacing/padding so separators remain independent from link hover/active states

## Test plan
- [ ] Run the site locally and open the home page
- [ ] Verify the header nav appears as a centered plaque with gold accents and separators between all links
- [ ] Confirm star separators do not react on link hover or active states
- [ ] Confirm link spacing and centering look balanced on desktop and mobile widths

Made with [Cursor](https://cursor.com)